### PR TITLE
fix defective type specifications

### DIFF
--- a/lib/exgencode.ex
+++ b/lib/exgencode.ex
@@ -7,13 +7,15 @@ defmodule Exgencode do
     @doc "Returns the size of the field in bits."
     def sizeof(pdu, fieldName)
     @doc "Encode the Elixir structure into a binary give the protocol version."
+    @spec encode(Exgencode.pdu, nil | Version.version) :: binary
     def encode(pdu, version)
     @doc "Decode a binary into the specified Elixir structure."
+    @spec decode(Exgencode.pdu, binary, nil | Version.version) :: {Exgencode.pdu, binary}
     def decode(pdu, binary, version)
   end
 
   @typedoc "A PDU, that is an Elixir structure representing a PDU."
-  @type pdu :: %{}
+  @type pdu :: map()
   @typedoc "PDU name, must be a structure name"
   @type pduName :: module
   @typedoc "The type of the field."
@@ -171,7 +173,7 @@ defmodule Exgencode do
 
   
   """
-  @spec defpdu(pduName, [{fieldName, fieldParam}]) :: none
+  @spec defpdu(pduName, [{fieldName, fieldParam}]) :: any
   defmacro defpdu name, originalFieldList do
     fieldList = for {fieldName, props} <- originalFieldList do
       fieldSize = props[:size]    

--- a/lib/pdu.ex
+++ b/lib/pdu.ex
@@ -34,7 +34,7 @@ defmodule Exgencode.Pdu do
       iex> Exgencode.Pdu.encode(%TestPdu.VersionedMsg{newerField: 111, evenNewerField: 7}, "2.0.0")
       << 10 :: size(16), 111 :: size(8) >>
   """
-  @spec encode(Exgencode.pdu, Version.version) :: binary
+  @spec encode(Exgencode.pdu, nil | Version.version) :: binary
   def encode(pdu, version \\ nil), do: Exgencode.Pdu.Protocol.encode(pdu, version)
 
   @doc """
@@ -58,7 +58,7 @@ defmodule Exgencode.Pdu do
       {%TestPdu.VersionedMsg{oldField: 10, newerField: 111}, <<>>} 
 
   """
-  @spec decode(Exgencode.pdu, binary, Version.version) :: {Exgencode.pdu, binary}
+  @spec decode(Exgencode.pdu, binary, nil | Version.version) :: {Exgencode.pdu, binary}
   def decode(pdu, binary, version \\ nil), do: Exgencode.Pdu.Protocol.decode(pdu, binary, version)
     
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,8 @@ defmodule Exgencode.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.14", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.14", only: :dev, runtime: false},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 


### PR DESCRIPTION
The defective type specifications give problems when trying to typecheck any project that uses exgencode.